### PR TITLE
Improve polling error handling

### DIFF
--- a/docs/observability/built-in-instrumentation.md
+++ b/docs/observability/built-in-instrumentation.md
@@ -28,7 +28,15 @@ Here's an example trace, when producing a batch of messages, which includes the 
 
 ## Metrics
 
-Finally, OutboxKit also exposes some metrics. Metrics exposed include number of batches produced, number of messages produced, and number of processed messages cleaned.
+Finally, OutboxKit also exposes some metrics.
+
+Metrics exposed include:
+
+- number of batches produced
+- number of messages produced
+- number of processed messages cleaned
+- polling cycles and their results
+- produced messages pending completion, the amount of retry attempts and messages retried
 
 Below you can see a sample dashboard, but note that only the final row is from OutboxKit, the others are from other sources.
 

--- a/samples/mysql/MySqlEndToEndPollingSample/Producer/Program.cs
+++ b/samples/mysql/MySqlEndToEndPollingSample/Producer/Program.cs
@@ -8,7 +8,6 @@ using OpenTelemetry.Trace;
 using YakShaveFx.OutboxKit.Core;
 using YakShaveFx.OutboxKit.MySql;
 using Dapper;
-using Microsoft.AspNetCore.Mvc;
 using MySqlEndToEndPollingSample.ProducerShared;
 using RabbitMQ.Client;
 using YakShaveFx.OutboxKit.Core.OpenTelemetry;

--- a/samples/mysql/MySqlEndToEndPollingSample/grafana-dashboard.json
+++ b/samples/mysql/MySqlEndToEndPollingSample/grafana-dashboard.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 6,
   "links": [],
   "panels": [
     {
@@ -70,8 +70,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -97,11 +96,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -114,7 +114,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "producer {{instance}}",
+          "legendFormat": "all",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -172,8 +172,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -199,11 +198,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -274,8 +274,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -301,11 +300,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -318,7 +318,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "producer",
+          "legendFormat": "all",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -376,8 +376,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -403,11 +402,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -474,8 +474,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -501,11 +500,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -514,11 +514,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(irate(outbox_produced_batches_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval]))",
+          "expr": "sum(irate(outboxkit_produced_batches_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "producer",
+          "legendFormat": "all",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -576,8 +576,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -603,11 +602,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -616,7 +616,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "irate(outbox_produced_batches_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval])",
+          "expr": "irate(outboxkit_produced_batches_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -678,8 +678,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -705,11 +704,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -719,7 +719,7 @@
           "editorMode": "code",
           "expr": "sum(irate(rabbitmq_consumer_consumed_messages_total{job=\"MySqlEndToEndPollingSample.Consumer\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "consumer {{instance}}",
+          "legendFormat": "all",
           "range": true,
           "refId": "A"
         }
@@ -776,8 +776,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -803,11 +802,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -824,23 +824,383 @@
       ],
       "title": "Messages consumed per second (by consumer)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(result) (irate(outboxkit_polling_cycles_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{result}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Polling cycles per second (all producers)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 40
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(irate(outboxkit_completion_retry_attempts_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "attempts",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Completion retry attempts per second (all producers)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 40
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(irate(outboxkit_completion_retried_messages_total{job=~\"MySqlEndToEndPollingSample.*Producer\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "messages",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Completion retried messages per second (all producers)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(outboxkit_messages_pending_completion_retry{job=~\"MySqlEndToEndPollingSample.*Producer\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pending",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Messages pending completion (all producers)",
+      "type": "timeseries"
     }
   ],
   "preload": false,
   "refresh": "5s",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "throughput",
+  "title": "OutboxKit Sample",
   "uid": "be2rtlvr0ia68a",
-  "version": 5,
-  "weekStart": ""
+  "version": 6
 }

--- a/src/Core/CleanUp/CleanUpBackgroundService.cs
+++ b/src/Core/CleanUp/CleanUpBackgroundService.cs
@@ -10,7 +10,7 @@ internal sealed partial class CleanUpBackgroundService(
     IOutboxCleaner cleaner,
     TimeProvider timeProvider,
     CoreCleanUpSettings settings,
-    CleanerMetrics metrics,
+    CleanerBackgroundServiceMetrics metrics,
     ILogger<CleanUpBackgroundService> logger) : BackgroundService
 {
     private readonly TimeSpan _cleanUpInterval = settings.CleanUpInterval;

--- a/src/Core/OpenTelemetry/ActivityShared.cs
+++ b/src/Core/OpenTelemetry/ActivityShared.cs
@@ -80,7 +80,7 @@ internal static class ActivityExtensions
 
     private static string ToInvariantString(this Exception exception)
     {
-        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+        var originalUiCulture = Thread.CurrentThread.CurrentUICulture;
 
         try
         {
@@ -89,7 +89,7 @@ internal static class ActivityExtensions
         }
         finally
         {
-            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            Thread.CurrentThread.CurrentUICulture = originalUiCulture;
         }
     }
 }

--- a/src/Core/OpenTelemetry/CleanerBackgroundServiceMetrics.cs
+++ b/src/Core/OpenTelemetry/CleanerBackgroundServiceMetrics.cs
@@ -1,21 +1,23 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants.CleanUpBackgroundService;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants;
 
 namespace YakShaveFx.OutboxKit.Core.OpenTelemetry;
 
-internal sealed class CleanerMetrics : IDisposable
+internal sealed class CleanerBackgroundServiceMetrics : IDisposable
 {
     private readonly Meter _meter;
     private readonly Counter<long> _cleanedMessagesCounter;
 
-    public CleanerMetrics(IMeterFactory meterFactory)
+    public CleanerBackgroundServiceMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(Constants.MeterName);
         
         _cleanedMessagesCounter = _meter.CreateCounter<long>(
-            "outbox.cleaned_messages",
-            unit: "{message}",
-            description: "The number processed outbox messages cleaned");
+            CleanedMessages.Name,
+            CleanedMessages.Unit,
+            CleanedMessages.Description);
     }
     
     public void MessagesCleaned(OutboxKey key, int count)
@@ -24,8 +26,8 @@ internal sealed class CleanerMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _cleanedMessagesCounter.Add(count, tags);
         }

--- a/src/Core/OpenTelemetry/CompletionRetrierMetrics.cs
+++ b/src/Core/OpenTelemetry/CompletionRetrierMetrics.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants.CompletionRetrier;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants;
 
 namespace YakShaveFx.OutboxKit.Core.OpenTelemetry;
 
@@ -15,19 +17,19 @@ internal sealed class CompletionRetrierMetrics : IDisposable
         _meter = meterFactory.Create(Constants.MeterName);
         
         _completionRetryAttemptsCounter = _meter.CreateCounter<long>(
-            "outbox.completion_retry_attempts",
-            unit: "{attempt}",
-            description: "The number of attempts to retry completion of produced messages");
+            CompletionRetryAttempts.Name,
+            CompletionRetryAttempts.Unit,
+            CompletionRetryAttempts.Description);
         
         _completionRetriedMessagesCounter = _meter.CreateCounter<long>(
-            "outbox.completion_retried_messages",
-            unit: "{message}",
-            description: "The number of messages for which completion was retried");
+            CompletionRetriedMessages.Name, 
+            CompletionRetriedMessages.Unit, 
+            CompletionRetriedMessages.Description);
         
         _pendingRetryCounter = _meter.CreateUpDownCounter<int>(
-            "outbox.messages_pending_completion_retry", 
-            unit: "{message}",
-            description: "The number of messages pending completion retry");
+            PendingRetry.Name,
+            PendingRetry.Unit,
+            PendingRetry.Description);
     }
     
     public void CompletionRetryAttempted(OutboxKey key, int count)
@@ -36,8 +38,8 @@ internal sealed class CompletionRetrierMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _completionRetryAttemptsCounter.Add(1, tags);
         }
@@ -46,8 +48,8 @@ internal sealed class CompletionRetrierMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _completionRetriedMessagesCounter.Add(count, tags);
         }
@@ -59,8 +61,8 @@ internal sealed class CompletionRetrierMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _pendingRetryCounter.Add(count, tags);
         }
@@ -72,8 +74,8 @@ internal sealed class CompletionRetrierMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _pendingRetryCounter.Add(-count, tags);
         }

--- a/src/Core/OpenTelemetry/MetricsShared.cs
+++ b/src/Core/OpenTelemetry/MetricsShared.cs
@@ -1,0 +1,86 @@
+namespace YakShaveFx.OutboxKit.Core.OpenTelemetry;
+
+internal static class MetricsConstants
+{
+    private const string MeterNamePrefix = "outboxkit.";
+
+    public static class PollingBackgroundService
+    {
+        public static class PollingCycles
+        {
+            public const string Name = MeterNamePrefix + "polling_cycles";
+            public const string Unit = "{cycle}";
+            public const string Description = "The number of polling cycles executed by the background service";
+            
+            public static class Tags
+            {
+                public const string Result = "result";
+            }
+        }
+    }
+
+    public static class CleanUpBackgroundService
+    {
+        public static class CleanedMessages
+        {
+            public const string Name = MeterNamePrefix + "cleaned_messages";
+            public const string Unit = "{message}";
+            public const string Description = "The number of processed outbox messages cleaned";
+        }
+    }
+
+    public static class CompletionRetrier
+    {
+        public static class CompletionRetryAttempts
+        {
+            public const string Name = MeterNamePrefix + "completion_retry_attempts";
+            public const string Unit = "{attempt}";
+            public const string Description = "The number of attempts to retry completion of produced messages";
+        }
+
+        public static class CompletionRetriedMessages
+        {
+            public const string Name = MeterNamePrefix + "completion_retried_messages";
+            public const string Unit = "{message}";
+            public const string Description = "The number of messages for which completion was retried (retrying the same message multiple times counts as one message)";
+        }
+
+        public static class PendingRetry
+        {
+            public const string Name = MeterNamePrefix + "messages_pending_completion_retry";
+            public const string Unit = "{message}";
+            public const string Description = "The number of messages pending completion retry";
+        }
+    }
+
+    public static class PollingProducer
+    {
+        public static class ProducedBatches
+        {
+            public const string Name = MeterNamePrefix + "produced_batches";
+            public const string Unit = "{batch}";
+            public const string Description = "The number of batches produced";
+
+            public static class Tags
+            {
+                public const string AllMessagesProduced = "all_messages_produced";
+            }
+        }
+
+        public static class ProducedMessages
+        {
+            public const string Name = MeterNamePrefix + "produced_messages";
+            public const string Unit = "{message}";
+            public const string Description = "The number of messages produced";
+        }
+    }
+
+    public static class Shared
+    {
+        public static class Tags
+        {
+            public const string ProviderKeyTag = "provider_key";
+            public const string ClientKeyTag = "client_key";
+        }
+    }
+}

--- a/src/Core/OpenTelemetry/PollingBackgroundServiceMetrics.cs
+++ b/src/Core/OpenTelemetry/PollingBackgroundServiceMetrics.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using YakShaveFx.OutboxKit.Core.Polling;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants.PollingBackgroundService;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants;
+
+namespace YakShaveFx.OutboxKit.Core.OpenTelemetry;
+
+internal sealed class PollingBackgroundServiceMetrics : IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Counter<long> _pollingCyclesCounter;
+
+    public PollingBackgroundServiceMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(Constants.MeterName);
+        
+        _pollingCyclesCounter = _meter.CreateCounter<long>(
+            PollingCycles.Name,
+            PollingCycles.Unit,
+            PollingCycles.Description);
+    }
+    
+    public void PollingCycleExecuted(OutboxKey key, ProducePendingResult result)
+    {
+        if (_pollingCyclesCounter.Enabled)
+        {
+            var tags = new TagList
+            {
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey },
+                { PollingCycles.Tags.Result, GetResultTagValue(result) }
+            };
+            _pollingCyclesCounter.Add(1, tags);
+        }
+    }
+    
+    private static string GetResultTagValue(ProducePendingResult result)
+    {
+        return result switch
+        {
+            ProducePendingResult.Ok => nameof(ProducePendingResult.Ok),
+            ProducePendingResult.FetchError => nameof(ProducePendingResult.FetchError),
+            ProducePendingResult.ProduceError => nameof(ProducePendingResult.ProduceError),
+            ProducePendingResult.PartialProduction => nameof(ProducePendingResult.PartialProduction),
+            ProducePendingResult.CompleteError => nameof(ProducePendingResult.CompleteError),
+            _ => ThrowInvalidResultException(result)
+        };
+
+        static string ThrowInvalidResultException(ProducePendingResult result) 
+            => throw new ArgumentOutOfRangeException(nameof(result), result, $"Unknown value {result}");
+    }
+
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Core/OpenTelemetry/PollingProducerMetrics.cs
+++ b/src/Core/OpenTelemetry/PollingProducerMetrics.cs
@@ -1,27 +1,29 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants.PollingProducer;
+using static YakShaveFx.OutboxKit.Core.OpenTelemetry.MetricsConstants;
 
 namespace YakShaveFx.OutboxKit.Core.OpenTelemetry;
 
-internal sealed class ProducerMetrics : IDisposable
+internal sealed class PollingProducerMetrics : IDisposable
 {
     private readonly Meter _meter;
     private readonly Counter<long> _producedBatchesCounter;
     private readonly Counter<long> _producedMessagesCounter;
 
-    public ProducerMetrics(IMeterFactory meterFactory)
+    public PollingProducerMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(Constants.MeterName);
         
         _producedBatchesCounter = _meter.CreateCounter<long>(
-            "outbox.produced_batches",
-            unit: "{batch}",
-            description: "The number of batches produced");
+            ProducedBatches.Name,
+            ProducedBatches.Unit,
+            ProducedBatches.Description);
         
         _producedMessagesCounter = _meter.CreateCounter<long>(
-            "outbox.produced_messages",
-            unit: "{message}",
-            description: "The number of messages produced");
+            ProducedMessages.Name,
+            ProducedMessages.Unit,
+            ProducedMessages.Description);
     }
     
     public void BatchProduced(OutboxKey key, bool allMessagesProduced)
@@ -30,9 +32,9 @@ internal sealed class ProducerMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey },
-                { "all_messages_produced", allMessagesProduced }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey },
+                { ProducedBatches.Tags.AllMessagesProduced, allMessagesProduced }
             };
             _producedBatchesCounter.Add(1, tags);
         }
@@ -44,8 +46,8 @@ internal sealed class ProducerMetrics : IDisposable
         {
             var tags = new TagList
             {
-                { "provider_key", key.ProviderKey },
-                { "client_key", key.ClientKey }
+                { Shared.Tags.ProviderKeyTag, key.ProviderKey },
+                { Shared.Tags.ClientKeyTag, key.ClientKey }
             };
             _producedMessagesCounter.Add(count, tags);
         }

--- a/src/Core/Polling/CompletionRetrier.cs
+++ b/src/Core/Polling/CompletionRetrier.cs
@@ -79,9 +79,8 @@ internal sealed partial class CompletionRetrier(
                 }
             },
             ct);
-
-    // logging as warning instead of error, as this is a retry, it's kind of expected that something might be wrong
-    [LoggerMessage(LogLevel.Warning,
+    
+    [LoggerMessage(LogLevel.Error,
         Message =
             "Error while retrying message completion for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
     private static partial void LogRetryFailed(ILogger logger, string providerKey, string clientKey, Exception ex);

--- a/src/Core/Polling/PollingBackgroundService.cs
+++ b/src/Core/Polling/PollingBackgroundService.cs
@@ -13,6 +13,7 @@ internal sealed partial class PollingBackgroundService(
     ILogger<PollingBackgroundService> logger) : BackgroundService
 {
     private readonly TimeSpan _pollingInterval = settings.PollingInterval;
+    private readonly ProduceIssueBackoffCalculator _backoffCalculator = new();
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -24,11 +25,28 @@ internal sealed partial class PollingBackgroundService(
         {
             try
             {
-                await completionRetrier.RetryAsync(stoppingToken);
-                
                 try
                 {
-                    await producer.ProducePendingAsync(stoppingToken);
+                    var result = await producer.ProducePendingAsync(stoppingToken);
+                    switch (result)
+                    {
+                        case ProducePendingResult.AllDone:
+                            _backoffCalculator.Reset();
+                            await WaitBeforeNextIteration(stoppingToken);
+                            break;
+                        case ProducePendingResult.CompleteError:
+                            _backoffCalculator.Reset();
+                            await completionRetrier.RetryAsync(stoppingToken);
+                            break;
+                        case ProducePendingResult.FetchError:
+                        case ProducePendingResult.ProduceError:
+                        case ProducePendingResult.PartialProduction:
+                            var backoff = _backoffCalculator.CalculateForResult(result);
+                            await Task.Delay(backoff, timeProvider, stoppingToken);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unexpected {nameof(ProducePendingResult)} {result}");
+                    }
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
@@ -37,11 +55,16 @@ internal sealed partial class PollingBackgroundService(
                 }
                 catch (Exception ex)
                 {
+                    // as IPollingProducer is handling a lot of potential error scenarios,
+                    // this is unlikely to happen, but better be prepared anyway
+
                     // we don't want the background service to stop while the application continues, so catching and logging
                     LogUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
-                }
 
-                await WaitBeforeNextIteration(stoppingToken);
+                    // if we get an unexpected error, it's probably best to use the same kind of strategies as for the coded for ones
+                    var backoff = _backoffCalculator.CalculateForUnhandledException();
+                    await Task.Delay(backoff, timeProvider, stoppingToken);
+                }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -56,7 +79,7 @@ internal sealed partial class PollingBackgroundService(
     {
         // no need to even try to wait if the service is stopping
         if (ct.IsCancellationRequested) return;
-        
+
         // to avoid letting the delays running in the background, wasting resources
         // we create a linked token, to cancel them
         using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -82,10 +105,12 @@ internal sealed partial class PollingBackgroundService(
     [LoggerMessage(LogLevel.Debug,
         Message =
             "Starting outbox polling background service for provider key \"{providerKey}\" and client key \"{clientKey}\", with polling interval {pollingInterval}")]
-    private static partial void LogStarting(ILogger logger, string providerKey, string clientKey, TimeSpan pollingInterval);
+    private static partial void LogStarting(ILogger logger, string providerKey, string clientKey,
+        TimeSpan pollingInterval);
 
     [LoggerMessage(LogLevel.Debug,
-        Message = "Shutting down outbox polling background service for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
+        Message =
+            "Shutting down outbox polling background service for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
     private static partial void LogStopping(ILogger logger, string providerKey, string clientKey);
 
     [LoggerMessage(LogLevel.Debug,

--- a/src/Core/Polling/PollingProducer.cs
+++ b/src/Core/Polling/PollingProducer.cs
@@ -6,7 +6,7 @@ namespace YakShaveFx.OutboxKit.Core.Polling;
 
 internal enum ProducePendingResult
 {
-    AllDone,
+    Ok,
     FetchError,
     ProduceError,
     PartialProduction,
@@ -24,7 +24,7 @@ internal sealed partial class PollingProducer(
     IBatchFetcher fetcher,
     IBatchProducer producer,
     ICompletionRetryCollector completionRetryCollector,
-    ProducerMetrics metrics,
+    PollingProducerMetrics metrics,
     ILogger<PollingProducer> logger) : IPollingProducer
 {
     private enum ProduceBatchResult
@@ -50,7 +50,7 @@ internal sealed partial class PollingProducer(
                 case ProduceBatchResult.MoreAvailable:
                     continue;
                 case ProduceBatchResult.AllDone:
-                    return ProducePendingResult.AllDone;
+                    return ProducePendingResult.Ok;
                 case ProduceBatchResult.FetchError:
                     return ProducePendingResult.FetchError;
                 case ProduceBatchResult.ProduceError:
@@ -66,7 +66,7 @@ internal sealed partial class PollingProducer(
         }
 
         // if we reach here, it means the cancellation token was triggered
-        return ProducePendingResult.AllDone;
+        return ProducePendingResult.Ok;
     }
 
     // returns true if there is a new batch to produce, false otherwise

--- a/src/Core/Polling/PollingProducer.cs
+++ b/src/Core/Polling/PollingProducer.cs
@@ -4,10 +4,19 @@ using YakShaveFx.OutboxKit.Core.OpenTelemetry;
 
 namespace YakShaveFx.OutboxKit.Core.Polling;
 
+internal enum ProducePendingResult
+{
+    AllDone,
+    FetchError,
+    ProduceError,
+    PartialProduction,
+    CompleteError
+}
+
 // yes, this interface was created just to allow for using a test double, was the simpler thing I could come up with
 internal interface IPollingProducer
 {
-    Task ProducePendingAsync(CancellationToken ct);
+    Task<ProducePendingResult> ProducePendingAsync(CancellationToken ct);
 }
 
 internal sealed partial class PollingProducer(
@@ -18,59 +27,160 @@ internal sealed partial class PollingProducer(
     ProducerMetrics metrics,
     ILogger<PollingProducer> logger) : IPollingProducer
 {
-    public async Task ProducePendingAsync(CancellationToken ct)
+    private enum ProduceBatchResult
     {
-        // Invokes ProduceBatchAsync while batches are being produce, to exhaust all pending messages.
+        MoreAvailable,
+        AllDone,
+        FetchError,
+        ProduceError,
+        PartialProduction,
+        CompleteError
+    }
 
-        // ReSharper disable once EmptyEmbeddedStatement - the logic is part of the method invoked in the condition 
-        while (!ct.IsCancellationRequested && await ProduceBatchAsync(ct)) ;
+    public async Task<ProducePendingResult> ProducePendingAsync(CancellationToken ct)
+    {
+        // invokes ProduceBatchAsync while batches are being produce, to exhaust all pending messages.
+
+        while (!ct.IsCancellationRequested)
+        {
+            var result = await ProduceBatchAsync(ct);
+
+            switch (result)
+            {
+                case ProduceBatchResult.MoreAvailable:
+                    continue;
+                case ProduceBatchResult.AllDone:
+                    return ProducePendingResult.AllDone;
+                case ProduceBatchResult.FetchError:
+                    return ProducePendingResult.FetchError;
+                case ProduceBatchResult.ProduceError:
+                    return ProducePendingResult.ProduceError;
+                case ProduceBatchResult.CompleteError:
+                    return ProducePendingResult.CompleteError;
+                case ProduceBatchResult.PartialProduction:
+                    return ProducePendingResult.PartialProduction;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected result from {nameof(ProduceBatchAsync)}: {result}");
+            }
+        }
+
+        // if we reach here, it means the cancellation token was triggered
+        return ProducePendingResult.AllDone;
     }
 
     // returns true if there is a new batch to produce, false otherwise
-    private async Task<bool> ProduceBatchAsync(CancellationToken ct)
+    private async Task<ProduceBatchResult> ProduceBatchAsync(CancellationToken ct)
     {
         using var activity = ActivityHelpers.StartActivity("produce outbox message batch", key);
 
-        await using var batchContext = await fetcher.FetchAndHoldAsync(ct);
-
-        var messages = batchContext.Messages;
-        activity?.SetTag(ActivityConstants.OutboxBatchSizeTag, messages.Count);
-
-        // if we got not messages, there either aren't messages available or are being produced concurrently
-        // in either case, we can break the loop
-        if (messages.Count <= 0) return false;
-
-        var result = await producer.ProduceAsync(key, messages, ct);
-        
-        metrics.BatchProduced(key, messages.Count == result.Ok.Count);
-        metrics.MessagesProduced(key, result.Ok.Count);
-
+        IBatchContext? batchContext = null;
         try
         {
-            // messages already produced, try to ack them
-            // not passing the actual cancellation token to try to complete the batch even if the application is shutting down
-            await batchContext.CompleteAsync(result.Ok, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            LogCompletionUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.RecordException(ex, new TagList
+            try
             {
-                { ActivityConstants.OutboxProviderKeyTag, key.ProviderKey },
-                { ActivityConstants.OutboxClientKeyTag, key.ClientKey }
-            });
-            completionRetryCollector.Collect(result.Ok);
-            
-            // return false to break the loop, as we don't want to produce more messages until we're able to complete the batch
-            return false;
-        }
+                batchContext = await fetcher.FetchAndHoldAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                LogFetchingUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
+                SetStatusAndRecordException(activity, ex);
+                return ProduceBatchResult.FetchError;
+            }
 
-        return await batchContext.HasNextAsync(ct);
+            BatchProduceResult? batchProduceResult;
+
+            try
+            {
+                var messages = batchContext.Messages;
+                activity?.SetTag(ActivityConstants.OutboxBatchSizeTag, messages.Count);
+
+                // if we got not messages, there either aren't messages available or are being produced concurrently
+                // in either case, we can break the loop
+                if (messages.Count <= 0) return ProduceBatchResult.AllDone;
+
+                batchProduceResult = await producer.ProduceAsync(key, messages, ct);
+
+                metrics.BatchProduced(key, messages.Count == batchProduceResult.Ok.Count);
+                metrics.MessagesProduced(key, batchProduceResult.Ok.Count);
+            }
+            catch (Exception ex)
+            {
+                LogProductionUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
+                SetStatusAndRecordException(activity, ex);
+                return ProduceBatchResult.ProduceError;
+            }
+
+            try
+            {
+                // messages already produced, try to ack them
+                // not passing the actual cancellation token to try to complete the batch even if the application is shutting down
+                await batchContext.CompleteAsync(batchProduceResult.Ok, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                LogCompletionUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
+                SetStatusAndRecordException(activity, ex);
+                completionRetryCollector.Collect(batchProduceResult.Ok);
+
+                // return to break the loop, as we don't want to produce more messages until we're able to complete the batch
+                return ProduceBatchResult.CompleteError;
+            }
+
+            if (batchProduceResult.Ok.Count < batchContext.Messages.Count)
+            {
+                // if we produced only a subset of the messages, something probably went wrong, so we want to handle it explicitly
+                return ProduceBatchResult.PartialProduction;
+            }
+
+            try
+            {
+                return await batchContext.HasNextAsync(ct)
+                    ? ProduceBatchResult.MoreAvailable
+                    : ProduceBatchResult.AllDone;
+            }
+            catch (Exception ex)
+            {
+                // equivalent to a fetch error, as it's just querying the db, so the handling should be the same
+                LogFetchingUnexpectedError(logger, key.ProviderKey, key.ClientKey, ex);
+                SetStatusAndRecordException(activity, ex);
+                return ProduceBatchResult.FetchError;
+            }
+        }
+        finally
+        {
+            if (batchContext is not null)
+            {
+                await batchContext.DisposeAsync();
+            }
+        }
     }
-    
+
+    private void SetStatusAndRecordException(Activity? activity, Exception ex)
+    {
+        activity?.SetStatus(ActivityStatusCode.Error);
+        activity?.RecordException(ex, new TagList
+        {
+            { ActivityConstants.OutboxProviderKeyTag, key.ProviderKey },
+            { ActivityConstants.OutboxClientKeyTag, key.ClientKey }
+        });
+    }
+
+    [LoggerMessage(LogLevel.Error,
+        Message =
+            "Unexpected error while fetching outbox messages for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
+    private static partial void LogFetchingUnexpectedError(ILogger logger, string providerKey, string clientKey,
+        Exception ex);
+
+    [LoggerMessage(LogLevel.Error,
+        Message =
+            "Unexpected error while producing outbox messages for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
+    private static partial void LogProductionUnexpectedError(ILogger logger, string providerKey, string clientKey,
+        Exception ex);
+
     [LoggerMessage(LogLevel.Error,
         Message =
             "Unexpected error while completing produced outbox messages for provider key \"{providerKey}\" and client key \"{clientKey}\"")]
-    private static partial void LogCompletionUnexpectedError(ILogger logger, string providerKey, string clientKey, Exception ex);
+    private static partial void LogCompletionUnexpectedError(ILogger logger, string providerKey, string clientKey,
+        Exception ex);
 }

--- a/src/Core/Polling/ProduceIssueBackoffCalculator.cs
+++ b/src/Core/Polling/ProduceIssueBackoffCalculator.cs
@@ -1,0 +1,59 @@
+namespace YakShaveFx.OutboxKit.Core.Polling;
+
+internal sealed class ProduceIssueBackoffCalculator
+{
+    private int _unhandledExceptionOccurrences;
+    private int _lastResultOccurrences;
+    private ProducePendingResult? _lastResult;
+
+    public void Reset()
+    {
+        ResetUnhandledException();
+        ResetResult();
+    }
+
+    public TimeSpan CalculateForUnhandledException()
+    {
+        ResetResult();
+        ++_unhandledExceptionOccurrences;
+        return BackoffForOccurrences(_unhandledExceptionOccurrences);
+    }
+
+    public TimeSpan CalculateForResult(ProducePendingResult result)
+    {
+        ResetUnhandledException();
+
+        if (result == _lastResult) ++_lastResultOccurrences;
+        else _lastResultOccurrences = 1;
+        _lastResult = result;
+
+        return result switch
+        {
+            ProducePendingResult.FetchError => BackoffForOccurrences(_lastResultOccurrences),
+            ProducePendingResult.ProduceError => BackoffForOccurrences(_lastResultOccurrences),
+            ProducePendingResult.PartialProduction => BackoffForOccurrences(_lastResultOccurrences),
+            _ => ThrowOnUnexpectedResult(result)
+        };
+
+        static TimeSpan ThrowOnUnexpectedResult(ProducePendingResult result)
+            => throw new InvalidOperationException($"Unexpected {nameof(ProducePendingResult)} {result}");
+    }
+
+    private void ResetUnhandledException() => _unhandledExceptionOccurrences = 0;
+
+    private void ResetResult()
+    {
+        _lastResultOccurrences = 0;
+        _lastResult = null;
+    }
+
+    private static TimeSpan BackoffForOccurrences(int occurrences)
+        => occurrences switch
+        {
+            1 => TimeSpan.FromSeconds(1),
+            2 => TimeSpan.FromSeconds(5),
+            3 => TimeSpan.FromSeconds(30),
+            4 => TimeSpan.FromMinutes(1),
+            _ => TimeSpan.FromMinutes(5)
+        };
+}

--- a/src/Core/ServiceCollectionExtensions.cs
+++ b/src/Core/ServiceCollectionExtensions.cs
@@ -38,8 +38,9 @@ public static class ServiceCollectionExtensions
 
     private static void AddOutboxKitPolling(IServiceCollection services, OutboxKitConfigurator configurator)
     {
-        services.AddSingleton<ProducerMetrics>();
+        services.AddSingleton<PollingProducerMetrics>();
         services.AddSingleton<CompletionRetrierMetrics>();
+        services.AddSingleton<PollingBackgroundServiceMetrics>();
         services.AddSingleton<RetrierBuilderFactory>();
 
         if (configurator.PollingConfigurators.Count == 1)
@@ -77,6 +78,7 @@ public static class ServiceCollectionExtensions
                 s.GetRequiredService<TimeProvider>(),
                 corePollingSettings,
                 s.GetRequiredKeyedService<ICompletionRetrier>(key),
+                s.GetRequiredService<PollingBackgroundServiceMetrics>(),
                 s.GetRequiredService<ILogger<PollingBackgroundService>>()));
 
             services.AddKeyedSingleton(
@@ -99,18 +101,18 @@ public static class ServiceCollectionExtensions
                 s.GetRequiredKeyedService<IBatchFetcher>(key),
                 s.GetRequiredService<IBatchProducer>(),
                 s.GetRequiredKeyedService<ICompletionRetryCollector>(key),
-                s.GetRequiredService<ProducerMetrics>(),
+                s.GetRequiredService<PollingProducerMetrics>(),
                 s.GetRequiredService<ILogger<PollingProducer>>()));
             
             if (corePollingSettings.EnableCleanUp)
             {
-                services.TryAddSingleton<CleanerMetrics>();
+                services.TryAddSingleton<CleanerBackgroundServiceMetrics>();
                 services.AddSingleton<IHostedService>(s => new CleanUpBackgroundService(
                     key,
                     s.GetRequiredKeyedService<IOutboxCleaner>(key),
                     s.GetRequiredService<TimeProvider>(),
                     cleanUpSettings,
-                    s.GetRequiredService<CleanerMetrics>(),
+                    s.GetRequiredService<CleanerBackgroundServiceMetrics>(),
                     s.GetRequiredService<ILogger<CleanUpBackgroundService>>()));
             }
 

--- a/tests/Core.Tests/CleanUp/CleanUpBackgroundServiceTests.cs
+++ b/tests/Core.Tests/CleanUp/CleanUpBackgroundServiceTests.cs
@@ -13,7 +13,7 @@ public class CleanUpBackgroundServiceTests
     private static readonly NullLogger<CleanUpBackgroundService> Logger = NullLogger<CleanUpBackgroundService>.Instance;
     private readonly FakeTimeProvider _timeProvider = new();
     private readonly CoreCleanUpSettings _settings = new();
-    private readonly CleanerMetrics _metrics = new(CreateMeterFactoryStub());
+    private readonly CleanerBackgroundServiceMetrics _metrics = new(CreateMeterFactoryStub());
     private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
 
     [Fact]

--- a/tests/Core.Tests/Polling/PollingBackgroundServiceMetricsTests.cs
+++ b/tests/Core.Tests/Polling/PollingBackgroundServiceMetricsTests.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using YakShaveFx.OutboxKit.Core.OpenTelemetry;
+using YakShaveFx.OutboxKit.Core.Polling;
+
+namespace YakShaveFx.OutboxKit.Core.Tests.Polling;
+
+public class PollingBackgroundServiceMetricsTests
+{
+    // this is less of test of correctness, and more to make sure that if new types of results are added, we don't forget to update the metrics
+    [Fact]
+    public void WhenReportingCycleExecutedThenAllResultsAreSupported()
+    {
+        const string instrumentName = MetricsConstants.PollingBackgroundService.PollingCycles.Name;
+        const string tagKey = MetricsConstants.PollingBackgroundService.PollingCycles.Tags.Result;
+        const string providerKeyTagKey = MetricsConstants.Shared.Tags.ProviderKeyTag;
+        const string providerKey = nameof(WhenReportingCycleExecutedThenAllResultsAreSupported);
+        const string clientKey = nameof(WhenReportingCycleExecutedThenAllResultsAreSupported);
+        
+        List<ProducePendingResult> resultsReported = [];
+        var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            var tagsArray = tags.ToArray();
+            var providerKeyTag = tagsArray.Single(t => t.Key == providerKeyTagKey);
+            
+            if (!providerKey.Equals(providerKeyTag.Value)) return;
+
+            var resultTag = tagsArray.Single(t => t.Key == tagKey);
+            resultsReported.Add(Enum.Parse<ProducePendingResult>(resultTag.Value!.ToString()!));
+
+        });
+        meterListener.Start();
+
+        using var sut = new PollingBackgroundServiceMetrics(OpenTelemetryHelpers.CreateMeterFactoryStub());
+        var possibleResults = Enum.GetValues<ProducePendingResult>();
+        foreach (var result in possibleResults)
+        {
+            sut
+                .Invoking(s => s.PollingCycleExecuted(new(providerKey, clientKey), result))
+                .Should()
+                .NotThrow();
+        }
+
+        resultsReported.Count.Should().Be(possibleResults.Length);
+        resultsReported.Should().BeEquivalentTo(possibleResults);
+    }
+}

--- a/tests/Core.Tests/Polling/PollingProducerTests.cs
+++ b/tests/Core.Tests/Polling/PollingProducerTests.cs
@@ -10,7 +10,7 @@ namespace YakShaveFx.OutboxKit.Core.Tests.Polling;
 public class PollingProducerTests
 {
     private static readonly OutboxKey Key = new("sample-provider", "some-key");
-    private static readonly ProducerMetrics Metrics = new(CreateMeterFactoryStub());
+    private static readonly PollingProducerMetrics Metrics = new(CreateMeterFactoryStub());
     private static readonly NullLogger<PollingProducer> Logger = NullLogger<PollingProducer>.Instance;
 
     private static readonly ICompletionRetryCollector CompleteRetryStub = new CompleteRetryRetryCollectorStub();

--- a/tests/Core.Tests/Polling/ProduceIssueBackoffCalculatorTests.cs
+++ b/tests/Core.Tests/Polling/ProduceIssueBackoffCalculatorTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using YakShaveFx.OutboxKit.Core.Polling;
+
+namespace YakShaveFx.OutboxKit.Core.Tests.Polling;
+
+public class ProduceIssueBackoffCalculatorTests
+{
+    [Fact]
+    internal void WhenCalculatingForUnhandledExceptionThenItIncreasesWithEachCallUntilALimit()
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var backoffCalculations = new[]
+        {
+            sut.CalculateForUnhandledException(),
+            sut.CalculateForUnhandledException(),
+            sut.CalculateForUnhandledException(),
+            sut.CalculateForUnhandledException(),
+            sut.CalculateForUnhandledException()
+        };
+
+        backoffCalculations[0].Should().BeLessThan(backoffCalculations[1]);
+        backoffCalculations[1].Should().BeLessThan(backoffCalculations[2]);
+        backoffCalculations[2].Should().BeLessThan(backoffCalculations[3]);
+        backoffCalculations[3].Should().BeLessThan(backoffCalculations[4]);
+    }
+    
+    [Theory]
+    [InlineData(ProducePendingResult.FetchError)]
+    [InlineData(ProducePendingResult.ProduceError)]
+    [InlineData(ProducePendingResult.PartialProduction)]
+    internal void WhenCalculatingForResultThenItIncreasesWithEachCallUntilALimit(ProducePendingResult result)
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var backoffCalculations = new[]
+        {
+            sut.CalculateForResult(result),
+            sut.CalculateForResult(result),
+            sut.CalculateForResult(result),
+            sut.CalculateForResult(result),
+            sut.CalculateForResult(result)
+        };
+
+        backoffCalculations[0].Should().BeLessThan(backoffCalculations[1]);
+        backoffCalculations[1].Should().BeLessThan(backoffCalculations[2]);
+        backoffCalculations[2].Should().BeLessThan(backoffCalculations[3]);
+        backoffCalculations[3].Should().BeLessThan(backoffCalculations[4]);
+    }
+    
+    [Theory]
+    [InlineData(ProducePendingResult.AllDone)]
+    [InlineData(ProducePendingResult.CompleteError)]
+    internal void WhenCalculatingForUnexpectedResultThenItThrows(ProducePendingResult result)
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var act = () => sut.CalculateForResult(result);
+        
+        act
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage($"Unexpected {nameof(ProducePendingResult)} {result}");
+    }
+    
+    [Fact]
+    internal void WhenCalculatingForDifferentResultsOrExceptionThenItResetsTheOccurrences()
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var backoffCalculations = new[]
+        {
+            sut.CalculateForResult(ProducePendingResult.FetchError),
+            sut.CalculateForResult(ProducePendingResult.ProduceError),
+            sut.CalculateForResult(ProducePendingResult.PartialProduction),
+            sut.CalculateForUnhandledException(),
+        };
+
+        backoffCalculations[0].Should().Be(backoffCalculations[1]);
+        backoffCalculations[1].Should().Be(backoffCalculations[2]);
+        backoffCalculations[2].Should().Be(backoffCalculations[3]);
+    }
+    
+    [Theory]
+    [InlineData(ProducePendingResult.FetchError)]
+    [InlineData(ProducePendingResult.ProduceError)]
+    [InlineData(ProducePendingResult.PartialProduction)]
+    internal void WhenResettingBetweenResultCalculationsThenItResetsTheOccurrences(ProducePendingResult result)
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var firstBackoff = sut.CalculateForResult(result);
+        sut.Reset();
+        var secondBackoff = sut.CalculateForResult(result);
+
+        firstBackoff.Should().Be(secondBackoff);
+    }
+    
+    [Fact]
+    internal void WhenResettingBetweenExceptionCalculationsThenItResetsTheOccurrences()
+    {
+        var sut = new ProduceIssueBackoffCalculator();
+        
+        var firstBackoff = sut.CalculateForUnhandledException();
+        sut.Reset();
+        var secondBackoff = sut.CalculateForUnhandledException();
+
+        firstBackoff.Should().Be(secondBackoff);
+    }
+}

--- a/tests/Core.Tests/Polling/ProduceIssueBackoffCalculatorTests.cs
+++ b/tests/Core.Tests/Polling/ProduceIssueBackoffCalculatorTests.cs
@@ -49,7 +49,7 @@ public class ProduceIssueBackoffCalculatorTests
     }
     
     [Theory]
-    [InlineData(ProducePendingResult.AllDone)]
+    [InlineData(ProducePendingResult.Ok)]
     [InlineData(ProducePendingResult.CompleteError)]
     internal void WhenCalculatingForUnexpectedResultThenItThrows(ProducePendingResult result)
     {


### PR DESCRIPTION
Closes #44, closes #35 

This PR improves error handling for polling message production, by identifying the stage at which errors happen, then applying different logic depending on it.

## Before

Before, any error occurring during message production (other than completion errors, recently worked on #45), would simply be caught, logged and polling would then proceed normally (with the typical delay between polling attempts).

Depending on the service usage patterns, this could have different, but in any case non-ideal results:

- high throughput - new messages available for production at short regular intervals, using the polling trigger optimization for reduced latency
  - in this scenario, the producer would be constantly triggered, never effectively applying the polling interval, which could cause additional stress on potentially struggling infrastructure
- low throughput - new messages available for production occasionally, at larger intervals
  - in this scenario, upon failure, retry would potentially only occur after the polling interval elapsed, increasing significantly the production latency

The first scenario is the most problematic, as it could contribute to further issues in the infrastructure, including making it harder to recover. Still, the second scenario is also not ideal, so it's relevant to take both into consideration.

## With this PR

This PR addresses the aforementioned issues by better identifying the result of the production attempt, including the stage at which potential errors occur, then applying different logic depending on it:

- if message production runs without issues, the polling interval/wait for trigger logic is applied as usual
- if message production fails at completion stage, then completion keeps being retried, with increasing backoff intervals* until it succeeds (implemented in #45)
- if message production fails at any other stage, then the typical polling interval/wait for trigger logic is replaced with suspending polling for an increasing interval*, which resets upon successful production, as well as when the stage at which the error occurred changes

\* Note that the the interval increase is capped. With this PR the intervals are set at 1s, 5s, 30s, 1m and 5m, being this last one used until reset. This might change in the future, or even be made configurable, but for now, should be good enough.